### PR TITLE
Check for grid folder (fix #34)

### DIFF
--- a/func/artwork.py
+++ b/func/artwork.py
@@ -24,6 +24,16 @@ def addartwork(appname, exe, userid, simplified_gamename):
     #Path to Steam grid folder
     artwork_path = os.path.expanduser("~") + '/.steam/steam/userdata/' + str(userid) + '/config/grid'
 
+    #Check if the folder exists, create if not
+    grid_exists = os.path.isdir(artwork_path)
+
+    if not grid_exists:
+        os.makedirs(artwork_path)
+        print("created grid folder:", artwork_path)
+
+    else:
+        print(artwork_path, "already exists")
+
     for i in os.listdir(artwork_path):
            
         if str(appid) in i:

--- a/func/artwork.py
+++ b/func/artwork.py
@@ -31,9 +31,6 @@ def addartwork(appname, exe, userid, simplified_gamename):
         os.makedirs(artwork_path)
         print("created grid folder:", artwork_path)
 
-    else:
-        print(artwork_path, "already exists")
-
     for i in os.listdir(artwork_path):
            
         if str(appid) in i:


### PR DESCRIPTION
Avoids script crash when there is no grid folder in Steam directory