### PR TITLE
Fix installation path in error message.

### DIFF
--- a/func/HeroicBashLauncher.py
+++ b/func/HeroicBashLauncher.py
@@ -104,5 +104,5 @@ if("Games/Heroic/" in os.getcwd()):
         os.system('zenity --error --title="Process Stopped" --text="Looks like you have not installed Heroic Games Launcher or installed any game\n\nPlease consider doing so and try again" --width=300')
         logging.error("Looks like you have not installed Heroic Games Launcher or installed any game\n\nPlease consider doing so and try again")
 else:
-    os.system('zenity --error --title="Process Stopped" --text="Please unzip or copy the HeroicBashLauncher folder to /Games/Heroic" --width=300')
-    logging.critical("Please unzip or copy the HeroicBashLauncher folder to /Games/Heroic")
+    os.system('zenity --error --title="Process Stopped" --text="Please unzip or copy the HeroicBashLauncher folder to ~/Games/Heroic" --width=300')
+    logging.critical("Please unzip or copy the HeroicBashLauncher folder to ~/Games/Heroic")


### PR DESCRIPTION
Fix the error message when not executing the installation script from `~/Games/Heroic`. I based the path on the follow entry from the 2.8.0 release notes:

> Prompt user to place HeroicBashLauncher in ~/Games/Heroic to avoid permission issues

It looks like the original code may work in other locations, but `/Games/Heroic` is likely wrong.