### PR TITLE
Improve checkbinary to attempt to find heroic binary on PATH

### DIFF
--- a/func/HeroicBashLauncher.py
+++ b/func/HeroicBashLauncher.py
@@ -8,109 +8,112 @@ from func.steam import createscript, addtosteam
 from func import settings
 
 #Check if Zenity is installed
-checkzenity = os.system('zenity --version')
+if __name__ == "__main__":
+    settings.check_connectivity()
+    settings.configure_argument_parser()
 
-#Version
-curr_version = "v3.1.1"
-print("Using Bash Launcher " + curr_version + "\nNOTE - This is an independent project and not affiliated with Heroic Games Launcher.\n")
+    #Version
+    curr_version = "v3.1.1"
+    print("Using Bash Launcher " + curr_version + "\nNOTE - This is an independent project and not affiliated with Heroic Games Launcher.\n")
+    checkzenity = os.system('zenity --version')
 
 
-if("Games/Heroic/" in os.getcwd()):
-    if (os.path.exists(configpath.legendaryinstalledpath) or os.path.exists(configpath.goginstalledpath)) and checkzenity == 0:
+    if("Games/Heroic/" in os.getcwd()):
+        if (os.path.exists(configpath.legendaryinstalledpath) or os.path.exists(configpath.goginstalledpath)) and checkzenity == 0:
 
-        #If len of arguments is 1 (no extra arguements), then proceed to create launch files for all games
-        #   else, update parameters of a game through launch file
+            #If len of arguments is 1 (no extra arguements), then proceed to create launch files for all games
+            #   else, update parameters of a game through launch file
 
-        if not settings.args.steam and not settings.args.update: #Only name of file as default argument
-        
-            #Setup logging
-            logging.basicConfig(filename='HeroicBashLauncher.log', filemode='w', level=logging.DEBUG, format='[%(levelname)s] %(message)s')
-
-            #Print current version
-            logging.info("Using Bash Launcher " + curr_version + "\nNOTE - This is an independent project and not affiliated with Heroic Games Launcher.\n")
+            if not settings.args.steam and not settings.args.update: #Only name of file as default argument
             
-            #Check if a newer version is available
-            new_release = False
-            checkifonline = True
+                #Setup logging
+                logging.basicConfig(filename='HeroicBashLauncher.log', filemode='w', level=logging.DEBUG, format='[%(levelname)s] %(message)s')
 
-            #Get new version tag if there's an internet connection
-            try:
-                release_info = requests.get("https://api.github.com/repos/redromnon/HeroicBashLauncher/releases/latest")
-                new_release_note = ("A newer version " + release_info.json()["tag_name"] + " is available!\n" +
-                                    "Please visit https://github.com/redromnon/HeroicBashLauncher/releases to download the latest release.")
+                #Print current version
+                logging.info("Using Bash Launcher " + curr_version + "\nNOTE - This is an independent project and not affiliated with Heroic Games Launcher.\n")
+                
+                #Check if a newer version is available
+                new_release = False
+                checkifonline = True
 
-                if curr_version != release_info.json()["tag_name"] and not release_info.json()["prerelease"]:
-                    new_release = True
-                    logging.info(new_release_note)
-            except:
-                checkifonline = False
-                logging.warning("No internet connection detected.\n\n")
+                #Get new version tag if there's an internet connection
+                try:
+                    release_info = requests.get("https://api.github.com/repos/redromnon/HeroicBashLauncher/releases/latest")
+                    new_release_note = ("A newer version " + release_info.json()["tag_name"] + " is available!\n" +
+                                        "Please visit https://github.com/redromnon/HeroicBashLauncher/releases to download the latest release.")
+
+                    if curr_version != release_info.json()["tag_name"] and not release_info.json()["prerelease"]:
+                        new_release = True
+                        logging.info(new_release_note)
+                except:
+                    checkifonline = False
+                    logging.warning("No internet connection detected.\n\n")
 
 
-            #Check if AppImage version is being used
-            if(os.path.isdir(os.getcwd() + '/binaries')):
-                logging.info("Detected 'binaries' folder. Making the binaries executable.")
-                os.system("chmod +x binaries/legendary")
-                os.system("chmod +x binaries/gogdl")
+                #Check if AppImage version is being used
+                if(os.path.isdir(os.getcwd() + '/binaries')):
+                    logging.info("Detected 'binaries' folder. Making the binaries executable.")
+                    os.system("chmod +x binaries/legendary")
+                    os.system("chmod +x binaries/gogdl")
 
+                
+                if "deck" in os.path.expanduser("~"):
+                    if not settings.args.silent:
+                        os.system('zenity --info --title="Process Starting" --text="This may take a while depending on your internet connection and number of games" --width=300 --timeout=8')
+                
+                #Setup/Read settings file
+                settings.create_settings_file()
+                settings.read_settings_file()
+
+                #Start creating scripts
+                listinstalled()
+
+                #Don't create AddToSteam script if Steam Deck 
+                if "deck" in os.path.expanduser("~") and settings.enable_autoaddtosteam:
+                    if not settings.args.silent:
+                        os.system('zenity --info --title="Process Finished" --text="Launch scripts stored in GameFiles folder\n\nYour games have been synced to Steam\n\nMake sure to launch newly installed games from Heroic first\n\nHave fun gaming!" --width=300 --timeout=8')
+                else:
+                    if not settings.args.silent:
+                        os.system('zenity --info --title="Process Finished" --text="Launch scripts stored in GameFiles folder\n\nYou can choose to add the launch scripts to any game launcher and sync games to Steam via AddToSteam\n\nMake sure to launch newly installed games from Heroic first\n\nHave fun gaming!" --width=300 --timeout=8')
+                    logging.info("Creating AddToSteam script...")
+                    createscript()
+
+                #Display new release dialog
+                if new_release and checkifonline:
+                    if not settings.args.silent:
+                        os.system('zenity --info --title="Process Paused" --text="' + new_release_note + '" --width=300')
+            elif settings.args.steam: #Contains simplified gamename as arg for Steam addition
+                
+                #Setup logging
+                logging.basicConfig(filename='AddToSteam.log', filemode='w', level=logging.DEBUG, format='[%(levelname)s] %(message)s')
+                
+                #Read settings file
+                settings.read_settings_file()
+                
+                logging.info("Running AddToSteam.sh...")
+                
+                if settings.args.steam[0] == "":
+                        logging.info("No game selected")
+                        sys.exit()
+                else:
+                    if not settings.args.silent:
+                        os.system('zenity --info --title="Process Running" --text="This may take a while depending on your internet connection and number of games" --width=350 --timeout=8')
+                    for i in settings.args.steam[0].split("|"):
+                        addtosteam(i.replace('"',''))
+
+                    if not settings.args.silent:
+                        os.system('zenity --info --title="Process Finished" --text="Check AddToSteam.log for details." --width=300') 
+            elif settings.args.update: #Update launch script
+                createlaunchfile(settings.args.update[0], settings.args.update[1], settings.args.update[2], settings.args.update[3])
+        elif checkzenity != 0:
             
-            if "deck" in os.path.expanduser("~"):
-                if not settings.args.silent:
-                    os.system('zenity --info --title="Process Starting" --text="This may take a while depending on your internet connection and number of games" --width=300 --timeout=8')
-            
-            #Setup/Read settings file
-            settings.create_settings_file()
-            settings.read_settings_file()
+            logging.error("Zenity not installed. Please consider doing so and try again.")
+        else:
 
-            #Start creating scripts
-            listinstalled()
-
-            #Don't create AddToSteam script if Steam Deck 
-            if "deck" in os.path.expanduser("~") and settings.enable_autoaddtosteam:
-                if not settings.args.silent:
-                    os.system('zenity --info --title="Process Finished" --text="Launch scripts stored in GameFiles folder\n\nYour games have been synced to Steam\n\nMake sure to launch newly installed games from Heroic first\n\nHave fun gaming!" --width=300 --timeout=8')
-            else:
-                if not settings.args.silent:
-                    os.system('zenity --info --title="Process Finished" --text="Launch scripts stored in GameFiles folder\n\nYou can choose to add the launch scripts to any game launcher and sync games to Steam via AddToSteam\n\nMake sure to launch newly installed games from Heroic first\n\nHave fun gaming!" --width=300 --timeout=8')
-                logging.info("Creating AddToSteam script...")
-                createscript()
-
-            #Display new release dialog
-            if new_release and checkifonline:
-                if not settings.args.silent:
-                    os.system('zenity --info --title="Process Paused" --text="' + new_release_note + '" --width=300')
-        elif settings.args.steam: #Contains simplified gamename as arg for Steam addition
-            
-            #Setup logging
-            logging.basicConfig(filename='AddToSteam.log', filemode='w', level=logging.DEBUG, format='[%(levelname)s] %(message)s')
-            
-            #Read settings file
-            settings.read_settings_file()
-            
-            logging.info("Running AddToSteam.sh...")
-            
-            if settings.args.steam[0] == "":
-                    logging.info("No game selected")
-                    sys.exit()
-            else:
-                if not settings.args.silent:
-                    os.system('zenity --info --title="Process Running" --text="This may take a while depending on your internet connection and number of games" --width=350 --timeout=8')
-                for i in settings.args.steam[0].split("|"):
-                    addtosteam(i.replace('"',''))
-
-                if not settings.args.silent:
-                    os.system('zenity --info --title="Process Finished" --text="Check AddToSteam.log for details." --width=300') 
-        elif settings.args.update: #Update launch script
-            createlaunchfile(settings.args.update[0], settings.args.update[1], settings.args.update[2], settings.args.update[3])
-    elif checkzenity != 0:
-        
-        logging.error("Zenity not installed. Please consider doing so and try again.")
+            if not settings.args.silent:
+                os.system('zenity --error --title="Process Stopped" --text="Looks like you have not installed Heroic Games Launcher or installed any game\n\nPlease consider doing so and try again" --width=300 --timeout=8')
+            logging.error("Looks like you have not installed Heroic Games Launcher or installed any game\n\nPlease consider doing so and try again")
     else:
-
         if not settings.args.silent:
-            os.system('zenity --error --title="Process Stopped" --text="Looks like you have not installed Heroic Games Launcher or installed any game\n\nPlease consider doing so and try again" --width=300 --timeout=8')
-        logging.error("Looks like you have not installed Heroic Games Launcher or installed any game\n\nPlease consider doing so and try again")
-else:
-    if not settings.args.silent:
-        os.system('zenity --error --title="Process Stopped" --text="Please unzip or copy the HeroicBashLauncher folder to ~/Games/Heroic" --width=300')
-    logging.critical("Please unzip or copy the HeroicBashLauncher folder to ~/Games/Heroic")
+            os.system('zenity --error --title="Process Stopped" --text="Please unzip or copy the HeroicBashLauncher folder to ~/Games/Heroic" --width=300')
+        logging.critical("Please unzip or copy the HeroicBashLauncher folder to ~/Games/Heroic")

--- a/func/checkbinary.py
+++ b/func/checkbinary.py
@@ -2,7 +2,7 @@
 #   For AppImage, check if alternavtive binary (Legendary) is added.
 #   If not, check folder under /tmp/ that includes path to the binaries.
 
-import os, json, sys, traceback, logging
+import json, logging, os, shutil, sys, traceback
 from func import configpath
 from func.settings import args
 
@@ -27,11 +27,15 @@ def getbinary(gametype):
         else:
             executable = "legendary "
 
-        # Follow any symlinks to the real path of heroic
         heroic_base_path = None
-        detected_heroic_path = os.path.realpath("/usr/bin/heroic")
-        if os.path.exists(detected_heroic_path):
-            heroic_base_path = os.path.dirname(detected_heroic_path)
+
+        # Attempt to find heroic on path
+        detected_heroic_path = shutil.which('heroic')
+        if detected_heroic_path:
+            # Follow any symlinks to the real path of heroic
+            detected_heroic_path = os.path.realpath(detected_heroic_path)
+            if os.path.exists(detected_heroic_path):
+                heroic_base_path = os.path.dirname(detected_heroic_path)
         elif os.path.exists("/opt/Heroic"): # Default to /opt/Heroic
             heroic_base_path = "/opt/Heroic"
         elif configpath.is_flatpak or os.path.exists("/app/bin/heroic"): #System or Flatpak-env path

--- a/func/checkbinary.py
+++ b/func/checkbinary.py
@@ -6,7 +6,7 @@ import os, json, sys, traceback, logging
 from func import configpath
 from func.settings import args
 
-__resources_bin_path = "resources/app.asar.unpacked/build/bin/linux"
+resources_bin_path = "resources/app.asar.unpacked/build/bin/linux"
 
 def getbinary(gametype):
 
@@ -21,8 +21,14 @@ def getbinary(gametype):
 
         #Checking
         binary = ""
+        
+        if gametype != "epic":
+            executable = "gogdl "
+        else:
+            executable = "legendary "
 
         # Follow any symlinks to the real path of heroic
+        heroic_base_path = None
         detected_heroic_path = os.path.realpath("/usr/bin/heroic")
         if os.path.exists(detected_heroic_path):
             heroic_base_path = os.path.dirname(detected_heroic_path)
@@ -30,16 +36,13 @@ def getbinary(gametype):
             heroic_base_path = "/opt/Heroic"
         elif configpath.is_flatpak or os.path.exists("/app/bin/heroic"): #System or Flatpak-env path
             heroic_base_path = "/app/bin/heroic"
-
-        heroic_resources_path = os.path.join(heroic_base_path, __resources_bin_path)
         
-        if gametype != "epic":
-            executable = "gogdl "
-        else:
-            executable = "legendary "
+        if heroic_base_path:
 
-        if os.path.exists(heroic_resources_path):
-            binary = os.path.join(heroic_resources_path, executable)
+            heroic_resources_path = os.path.join(heroic_base_path, resources_bin_path)
+
+            if os.path.exists(heroic_resources_path):
+                binary = os.path.join(heroic_resources_path, executable)
         elif 'altLegendaryBin' in heroicconfig['defaultSettings'].keys() and heroicconfig["defaultSettings"]["altLegendaryBin"] != "" and gametype == "epic":
 
                 binary = heroicconfig["defaultSettings"]["altLegendaryBin"] + " "

--- a/func/settings.py
+++ b/func/settings.py
@@ -2,19 +2,27 @@
 
 import os, json, logging, argparse, requests
 
-#Check for connectivity
 isoffline = False
-try:
-    requests.get("https://www.google.com", timeout=2)
-except:
-    isoffline = True
+
+#Check for connectivity
+def check_connectivity():
+    global isoffline
+    try:
+        requests.get("https://www.google.com", timeout=2)
+    except:
+        isoffline = True
+
 
 #Setup arguments
 parser = argparse.ArgumentParser()
-parser.add_argument("--silent", action="store_true", help="Run program without GUI")
-parser.add_argument("--steam", nargs=1, help="Add selected games to Steam")
-parser.add_argument("--update", nargs=4, help="Update launch script")
-args = parser.parse_args()
+args = argparse.Namespace()
+def configure_argument_parser():
+    global parser
+    global args
+    parser.add_argument("--silent", action="store_true", help="Run program without GUI")
+    parser.add_argument("--steam", nargs=1, help="Add selected games to Steam")
+    parser.add_argument("--update", nargs=4, help="Update launch script")
+    args = parser.parse_args()
 
 #Declare
 enable_epic = None

--- a/tests/checkbinarytest.py
+++ b/tests/checkbinarytest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import shutil
 from io import StringIO
 from unittest import main, mock, TestCase
 from unittest.mock import Mock
@@ -19,6 +20,9 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_opt(self):
+        shutil.which = Mock()
+        shutil.which.return_value = None
+
         os.path.exists = Mock()
         expected_base_path = "/opt/Heroic"
         expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
@@ -30,6 +34,9 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config)), create=True)
     def test_getbinary_epic_from_config(self):
+        shutil.which = Mock()
+        shutil.which.return_value = None
+
         os.path.exists = Mock()
         expected_base_path = "/config/path/to"
         expected_return_path = os.path.join(expected_base_path, "legendary ")
@@ -40,6 +47,9 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_is_flatpak(self):
+        shutil.which = Mock()
+        shutil.which.return_value = None
+
         configpath.is_flatpak = Mock()
         configpath.is_flatpak = True
         os.path.exists = Mock()
@@ -52,6 +62,9 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_app(self):
+        shutil.which = Mock()
+        shutil.which.return_value = None
+
         configpath.is_flatpak = Mock()
         configpath.is_flatpak = False
         os.path.exists = Mock()
@@ -65,6 +78,9 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_appimage_gamefiles(self):
+        shutil.which = Mock()
+        shutil.which.return_value = None
+
         expected_base_path = "/home/user/Games/Heroic/HeroicBashLauncher"
         os.getcwd = Mock()
         os.getcwd.return_value = os.path.join(expected_base_path, "GameFiles")
@@ -79,6 +95,9 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_appimage(self):
+        shutil.which = Mock()
+        shutil.which.return_value = None
+        
         expected_base_path = "/home/user/Games/Heroic/HeroicBashLauncher"
         os.getcwd = Mock()
         os.getcwd.return_value = os.path.join(expected_base_path)
@@ -88,6 +107,22 @@ class TestCheckBinary(TestCase):
         os.path.exists.side_effect = lambda x: x == expected_base_path or x == os.path.join(expected_base_path, "binaries")
 
         expected_return_path = os.path.join(expected_base_path, "binaries/legendary ")
+        actual_return_path = checkbinary.getbinary("epic")
+        assert expected_return_path == actual_return_path
+    
+    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
+    def test_getbinary_epic_on_path(self):
+        shutil.which = Mock()
+        shutil.which.side_effect = lambda x: "/usr/lib64/heroic-games-launcher-bin/heroic" if x == "heroic" else None
+
+        os.path.realpath = Mock()
+        os.path.realpath.side_effect = lambda x: "/usr/lib64/heroic-games-launcher-bin/heroic" if x == "/usr/lib64/heroic-games-launcher-bin/heroic" else x
+
+        os.path.exists = Mock()
+        expected_base_path = "/usr/lib64/heroic-games-launcher-bin"
+        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
+        os.path.exists.side_effect = lambda x: expected_base_path in x
+
         actual_return_path = checkbinary.getbinary("epic")
         assert expected_return_path == actual_return_path
 

--- a/tests/checkbinarytest.py
+++ b/tests/checkbinarytest.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+import os
+from io import StringIO
+from unittest import main, mock, TestCase
+from unittest.mock import Mock
+
+from func import configpath
+from func.settings import args
+from func import checkbinary
+
+args = Mock()
+args.silent = True
+
+mock_config_null = "{\"defaultSettings\": {\"altLegendaryBin\": \"\"}}"
+
+mock_config = "{\"defaultSettings\": {\"altLegendaryBin\": \"/config/path/to/legendary\"}}"
+
+class TestCheckBinary(TestCase):
+
+    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
+    def test_getbinary_epic_opt(self):
+        os.path.exists = Mock()
+        expected_base_path = "/opt/Heroic"
+        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
+        os.path.exists.side_effect = lambda x: expected_base_path in x
+
+        actual_return_path = checkbinary.getbinary("epic")
+        os.path.exists.assert_any_call(expected_base_path)
+        assert expected_return_path == actual_return_path
+
+    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config)), create=True)
+    def test_getbinary_epic_from_config(self):
+        os.path.exists = Mock()
+        expected_base_path = "/config/path/to"
+        expected_return_path = os.path.join(expected_base_path, "legendary ")
+        os.path.exists.side_effect = lambda x: expected_base_path in x
+
+        actual_return_path = checkbinary.getbinary("epic")
+        assert expected_return_path == actual_return_path
+
+    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
+    def test_getbinary_epic_is_flatpak(self):
+        configpath.is_flatpak = Mock()
+        configpath.is_flatpak = True
+        os.path.exists = Mock()
+        expected_base_path = "/app/bin/heroic"
+        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
+        os.path.exists.side_effect = lambda x: expected_base_path in x
+
+        actual_return_path = checkbinary.getbinary("epic")
+        assert expected_return_path == actual_return_path
+
+    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
+    def test_getbinary_epic_app(self):
+        configpath.is_flatpak = Mock()
+        configpath.is_flatpak = False
+        os.path.exists = Mock()
+        expected_base_path = "/app/bin/heroic"
+        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
+        os.path.exists.side_effect = lambda x: x == expected_base_path or x == os.path.join(expected_base_path, checkbinary.resources_bin_path)
+
+        actual_return_path = checkbinary.getbinary("epic")
+        os.path.exists.assert_any_call(expected_base_path)
+        assert expected_return_path == actual_return_path
+
+    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
+    def test_getbinary_epic_appimage_gamefiles(self):
+        expected_base_path = "/home/user/Games/Heroic/HeroicBashLauncher"
+        os.getcwd = Mock()
+        os.getcwd.return_value = os.path.join(expected_base_path, "GameFiles")
+        configpath.is_flatpak = Mock()
+        configpath.is_flatpak = False
+        os.path.exists = Mock()
+        os.path.exists.side_effect = lambda x: expected_base_path in x
+
+        expected_return_path = os.path.join(expected_base_path, "binaries/legendary ")
+        actual_return_path = checkbinary.getbinary("epic")
+        assert expected_return_path == actual_return_path
+
+    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
+    def test_getbinary_epic_appimage(self):
+        expected_base_path = "/home/user/Games/Heroic/HeroicBashLauncher"
+        os.getcwd = Mock()
+        os.getcwd.return_value = os.path.join(expected_base_path)
+        configpath.is_flatpak = Mock()
+        configpath.is_flatpak = False
+        os.path.exists = Mock()
+        os.path.exists.side_effect = lambda x: x == expected_base_path or x == os.path.join(expected_base_path, "binaries")
+
+        expected_return_path = os.path.join(expected_base_path, "binaries/legendary ")
+        actual_return_path = checkbinary.getbinary("epic")
+        assert expected_return_path == actual_return_path
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/testcheckbinary.py
+++ b/tests/testcheckbinary.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import json
 import shutil
 from io import StringIO
 from unittest import main, mock, TestCase
@@ -9,21 +10,31 @@ from func import configpath
 from func.settings import args
 from func import checkbinary
 
-args = Mock()
-args.silent = True
+mock_config_null = json.dumps({ "defaultSettings": { "altLegendaryBin": "" } })
 
-mock_config_null = "{\"defaultSettings\": {\"altLegendaryBin\": \"\"}}"
-
-mock_config = "{\"defaultSettings\": {\"altLegendaryBin\": \"/config/path/to/legendary\"}}"
+mock_config_obj = {"defaultSettings": {"altLegendaryBin": "/config/path/to/legendary"}}
+mock_config_str = json.dumps(mock_config_obj)
 
 class TestCheckBinary(TestCase):
 
-    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
-    def test_getbinary_epic_opt(self):
+    def setUp(self):
+        # By default which will return nothing (no heroic on PATH)
         shutil.which = Mock()
         shutil.which.return_value = None
 
+        # Initialize other mocks
+        os.getcwd = Mock()
         os.path.exists = Mock()
+        os.path.realpath = Mock()
+
+        # By default we won't test the flatpak path.
+        checkbinary.configpath = Mock() 
+        checkbinary.configpath.is_flatpak = False
+
+        checkbinary.args.silent = True
+
+    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
+    def test_getbinary_epic_opt(self):
         expected_base_path = "/opt/Heroic"
         expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
         os.path.exists.side_effect = lambda x: expected_base_path in x
@@ -32,14 +43,10 @@ class TestCheckBinary(TestCase):
         os.path.exists.assert_any_call(expected_base_path)
         assert expected_return_path == actual_return_path
 
-    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config)), create=True)
+    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_str)), create=True)
     def test_getbinary_epic_from_config(self):
-        shutil.which = Mock()
-        shutil.which.return_value = None
-
-        os.path.exists = Mock()
-        expected_base_path = "/config/path/to"
-        expected_return_path = os.path.join(expected_base_path, "legendary ")
+        expected_return_path = mock_config_obj["defaultSettings"]["altLegendaryBin"] + " "
+        expected_base_path = os.path.dirname(expected_return_path)
         os.path.exists.side_effect = lambda x: expected_base_path in x
 
         actual_return_path = checkbinary.getbinary("epic")
@@ -47,12 +54,8 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_is_flatpak(self):
-        shutil.which = Mock()
-        shutil.which.return_value = None
+        checkbinary.configpath.is_flatpak = True
 
-        configpath.is_flatpak = Mock()
-        configpath.is_flatpak = True
-        os.path.exists = Mock()
         expected_base_path = "/app/bin/heroic"
         expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
         os.path.exists.side_effect = lambda x: expected_base_path in x
@@ -62,12 +65,6 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_app(self):
-        shutil.which = Mock()
-        shutil.which.return_value = None
-
-        configpath.is_flatpak = Mock()
-        configpath.is_flatpak = False
-        os.path.exists = Mock()
         expected_base_path = "/app/bin/heroic"
         expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
         os.path.exists.side_effect = lambda x: x == expected_base_path or x == os.path.join(expected_base_path, checkbinary.resources_bin_path)
@@ -78,15 +75,8 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_appimage_gamefiles(self):
-        shutil.which = Mock()
-        shutil.which.return_value = None
-
         expected_base_path = "/home/user/Games/Heroic/HeroicBashLauncher"
-        os.getcwd = Mock()
         os.getcwd.return_value = os.path.join(expected_base_path, "GameFiles")
-        configpath.is_flatpak = Mock()
-        configpath.is_flatpak = False
-        os.path.exists = Mock()
         os.path.exists.side_effect = lambda x: expected_base_path in x
 
         expected_return_path = os.path.join(expected_base_path, "binaries/legendary ")
@@ -95,15 +85,8 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_appimage(self):
-        shutil.which = Mock()
-        shutil.which.return_value = None
-        
         expected_base_path = "/home/user/Games/Heroic/HeroicBashLauncher"
-        os.getcwd = Mock()
         os.getcwd.return_value = os.path.join(expected_base_path)
-        configpath.is_flatpak = Mock()
-        configpath.is_flatpak = False
-        os.path.exists = Mock()
         os.path.exists.side_effect = lambda x: x == expected_base_path or x == os.path.join(expected_base_path, "binaries")
 
         expected_return_path = os.path.join(expected_base_path, "binaries/legendary ")
@@ -112,13 +95,8 @@ class TestCheckBinary(TestCase):
     
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_on_path(self):
-        shutil.which = Mock()
         shutil.which.side_effect = lambda x: "/usr/lib64/heroic-games-launcher-bin/heroic" if x == "heroic" else None
-
-        os.path.realpath = Mock()
         os.path.realpath.side_effect = lambda x: "/usr/lib64/heroic-games-launcher-bin/heroic" if x == "/usr/lib64/heroic-games-launcher-bin/heroic" else x
-
-        os.path.exists = Mock()
         expected_base_path = "/usr/lib64/heroic-games-launcher-bin"
         expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
         os.path.exists.side_effect = lambda x: expected_base_path in x


### PR DESCRIPTION
Hello, thanks for this great tool. I've been using it for awhile now on my Fedora Linux system to quickly launch games from Steam while using the RPM-packaged version of Heroic Games Launcher from the recommended COPR repo ([atim/heroic-games-launcher](https://copr.fedorainfracloud.org/coprs/atim/heroic-games-launcher/)).

Unfortunately, due to the hard-coding of the expected paths of Heroic in HeroicBashLauncher, it wasn't working on my system at first because the RPM version of Heroic is installed to `/usr/lib64/heroic-games-launcher-bin/`. 

This PR attempts to fix this issue and allow for more "diverse" Heroic installations in the future by:
* Attempting to find `heroic` on the PATH before going back to the old defaulting logic.
* Including unit tests for checkbinary.py to confirm that each of the correct paths are returned in a few different scenarios.
    * These can be invoked with `python -m unittest tests/*.py`
    * A side-effect of making the modules testable required reorganizing the main `HeroicBashLauncher.py` to nest its code under an `if __name__ == "__main__":` block and converting a few of the checks in `settings.py` to be functions that are now called from this main method.