### PR TITLE
adding symlink support

### DIFF
--- a/func/HeroicBashLauncher.py
+++ b/func/HeroicBashLauncher.py
@@ -14,8 +14,9 @@ checkzenity = os.system('zenity --version')
 curr_version = "v3.1.1"
 print("Using Bash Launcher " + curr_version + "\nNOTE - This is an independent project and not affiliated with Heroic Games Launcher.\n")
 
+launcherDir = os.path.expanduser('~/Games/Heroic/HeroicBashLauncher')
 
-if("Games/Heroic/" in os.getcwd()):
+if os.path.exists(launcherDir):
     if (os.path.exists(configpath.legendaryinstalledpath) or os.path.exists(configpath.goginstalledpath)) and checkzenity == 0:
 
         #If len of arguments is 1 (no extra arguements), then proceed to create launch files for all games
@@ -48,7 +49,7 @@ if("Games/Heroic/" in os.getcwd()):
 
 
             #Check if AppImage version is being used
-            if(os.path.isdir(os.getcwd() + '/binaries')):
+            if(os.path.isdir(launcherDir + '/binaries')):
                 logging.info("Detected 'binaries' folder. Making the binaries executable.")
                 os.system("chmod +x binaries/legendary")
                 os.system("chmod +x binaries/gogdl")

--- a/func/steam.py
+++ b/func/steam.py
@@ -78,7 +78,7 @@ def calculate_last_srno(line):
 
 
 def addtosteam(gamename):
-        userdata_folder = os.path.join(os.path.expanduser("~"), '.steam' , 'steam', 'userdata')
+        userdata_folder = os.path.expanduser("~/.steam/steam/userdata")
 
         try:
 


### PR DESCRIPTION
Related to #111 

This does a different kind of check for the dir, so it will work with symlinks and stuff. I have the smallest steamdeck size, but a 1TB SD, so that's where I put things, and Heroic works fine with a sym-link from ~/Games/ to my SD, but not this script.

I can't seem to build it or even run it on steamdeck or in docker (my local machine is an intel mac) so you'll have to do the testing.