### PR TITLE
Fix Flatpak detection and prefer Flatpak when it is installed

### DIFF
--- a/func/checkbinary.py
+++ b/func/checkbinary.py
@@ -29,29 +29,32 @@ def getbinary(gametype):
 
         heroic_base_path = None
 
-        # Attempt to find heroic on path
-        detected_heroic_path = shutil.which('heroic')
-        if detected_heroic_path:
-            # Follow any symlinks to the real path of heroic
-            detected_heroic_path = os.path.realpath(detected_heroic_path)
-            if os.path.exists(detected_heroic_path):
-                heroic_base_path = os.path.dirname(detected_heroic_path)
-        elif os.path.exists("/opt/Heroic"): # Default to /opt/Heroic
-            heroic_base_path = "/opt/Heroic"
-        elif configpath.is_flatpak or os.path.exists("/app/bin/heroic"): #System or Flatpak-env path
+        if configpath.is_flatpak:
+            # Prefer flatpak if it is detected by configpath module.
             heroic_base_path = "/app/bin/heroic"
-        
+        else:
+            # Attempt to find heroic on path
+            detected_heroic_path = shutil.which('heroic')
+            if detected_heroic_path:
+                # Follow any symlinks to the real path of heroic
+                detected_heroic_path = os.path.realpath(detected_heroic_path)
+                if os.path.exists(detected_heroic_path):
+                    heroic_base_path = os.path.dirname(detected_heroic_path)
+            elif os.path.exists("/opt/Heroic"): # Check for to /opt/Heroic
+                heroic_base_path = "/opt/Heroic"
+            elif os.path.exists("/app/bin/heroic"): # Check for system path
+                heroic_base_path = "/app/bin/heroic"
+            
         if heroic_base_path:
 
             heroic_resources_path = os.path.join(heroic_base_path, resources_bin_path)
 
             binary = os.path.join(heroic_resources_path, executable)
         elif heroicconfig["defaultSettings"].get("altLegendaryBin") and gametype == "epic":
+            binary = heroicconfig["defaultSettings"]["altLegendaryBin"]
+        elif heroicconfig['defaultSettings'].get("altGogdlBin") and gametype != "epic":
+            binary = heroicconfig["defaultSettings"]["altGogdlBin"]
 
-                binary = heroicconfig["defaultSettings"]["altLegendaryBin"]
-        #elif 'altGogdlBin' in heroicconfig['defaultSettings'].keys() and heroicconfig["defaultSettings"]["altGogdlBin"] != "" and gametype != "epic":
-        
-                #binary = heroicconfig["defaultSettings"]["altGogdlBin"]
         else:#AppImage
             if "GameFiles" in os.getcwd():#select parent dir
                 binary = os.path.join(os.path.dirname(os.getcwd()), "binaries", executable)

--- a/func/configpath.py
+++ b/func/configpath.py
@@ -16,54 +16,54 @@ GOG
 
 '''
 import os
+import subprocess
 
-is_flatpak = False
+HGL_FLATPAK_APPID = "com.heroicgameslauncher.hgl"
+STEAM_FLATPAK_APPID = "com.valvesoftware.Steam"
 
-gamesjsonpath = os.path.expanduser("~") + "/.config/heroic/GamesConfig"
+flatpak_base_config_path = os.path.join(os.path.expanduser("~/.var/app/"), HGL_FLATPAK_APPID, "config")
+# Electron's app.getPath("appData") in Heroic Games Launcher will use XDG_CONFIG_HOME if it is set.
+native_base_config_path = os.environ.get("XDG_CONFIG_HOME") if os.environ.get("XDG_CONFIG_HOME") else os.path.expanduser("~/.config")
 
-heroicconfigpath = os.path.expanduser("~") + "/.config/heroic/config.json"
 
-legendaryinstalledpath = os.path.expanduser("~") + "/.config/legendary/installed.json"
-
-goginstalledpath = os.path.expanduser("~") + "/.config/heroic/gog_store/installed.json"
-
-goglibrarypath = os.path.expanduser("~") + "/.config/heroic/gog_store/library.json"
-
-heroiclibrarypath = os.path.expanduser("~") + "/.config/heroic/lib-cache/library.json"
-
-timestamppath = os.path.expanduser("~") + "/.config/heroic/store/timestamp.json"
-
-storejsonpath = os.path.expanduser("~") + "/.config/heroic/store/config.json"
-
-runtimepath = os.path.expanduser("~") + "/.config/heroic/tools/runtimes/"
-
+def is_flatpak_installed(application_id: str) -> bool:
+    """Given an application ID, returns if the flatpak is installed  and has been run once 
+    based on the output of the flatpak list command and the presence of the config folder"""
+    try:
+        r = subprocess.run(["flatpak", "list", "--columns=application"], capture_output=True)
+        return (r.returncode == 0 and # Flatpak command ran successfully
+            application_id in r.stdout.decode().splitlines() and  # Application ID is installed in Flatpak
+            os.path.exists(os.path.join(os.path.expanduser("~/.var/app/"), application_id)) # Config is present
+            )
+    except FileNotFoundError:
+        # flatpak command was not found
+        return False
 
 #Check if Flatpak exists
-if os.path.exists(os.path.expanduser("~") + "/.var/app/com.heroicgameslauncher.hgl/config/heroic"):
-
+if is_flatpak_installed(HGL_FLATPAK_APPID): # Heroic is installed and config is present
     is_flatpak = True
+    actual_config_path = flatpak_base_config_path
+else:
+    is_flatpak = False
+    actual_config_path = native_base_config_path
 
-    gamesjsonpath = os.path.expanduser("~") + "/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig"
+gamesjsonpath = os.path.join(actual_config_path, "heroic/GamesConfig")
 
-    heroicconfigpath = os.path.expanduser("~") + "/.var/app/com.heroicgameslauncher.hgl/config/heroic/config.json"
+heroicconfigpath = os.path.join(actual_config_path, "heroic/config.json")
 
-    legendaryinstalledpath = os.path.expanduser("~") + "/.var/app/com.heroicgameslauncher.hgl/config/legendary/installed.json"
+legendaryinstalledpath = os.path.join(actual_config_path, "legendary/installed.json")
 
-    goginstalledpath = os.path.expanduser("~") + "/.var/app/com.heroicgameslauncher.hgl/config/heroic/gog_store/installed.json"
+goginstalledpath = os.path.join(actual_config_path, "heroic/gog_store/installed.json")
 
-    goglibrarypath = os.path.expanduser("~") + "/.var/app/com.heroicgameslauncher.hgl/config/heroic/gog_store/library.json"
+goglibrarypath = os.path.join(actual_config_path, "heroic/gog_store/library.json")
 
-    heroiclibrarypath = os.path.expanduser("~") + "/.var/app/com.heroicgameslauncher.hgl/config/heroic/lib-cache/library.json"
+heroiclibrarypath = os.path.join(actual_config_path, "heroic/lib-cache/library.json")
 
-    timestamppath = os.path.expanduser("~") + "/.var/app/com.heroicgameslauncher.hgl/config/heroic/store/timestamp.json"
+timestamppath = os.path.join(actual_config_path, "heroic/store/timestamp.json")
 
-    storejsonpath = os.path.expanduser("~") + "/.var/app/com.heroicgameslauncher.hgl/config/heroic/store/config.json"
+storejsonpath = os.path.join(actual_config_path, "heroic/store/config.json")
 
-    runtimepath = os.path.expanduser("~") + "/.var/app/com.heroicgameslauncher.hgl/config/heroic/tools/runtimes/"
+runtimepath = os.path.join(actual_config_path, "heroic/tools/runtimes/")
 
-#Check if Steam is Flatpak
-is_steam_flatpak = False
-
-
-if os.path.exists(os.path.expanduser("~") + "/.var/app/com.valvesoftware.Steam"):
-    is_steam_flatpak = True
+# Check if Steam is Flatpak
+is_steam_flatpak =  is_flatpak_installed(STEAM_FLATPAK_APPID)

--- a/tests/testcheckbinary.py
+++ b/tests/testcheckbinary.py
@@ -33,6 +33,7 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_opt(self):
+        """Tests getting the path to legendary from the system /opt/Heroic path."""
         expected_base_path = "/opt/Heroic"
         expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary")
         os.path.exists.side_effect = lambda x: expected_base_path in x
@@ -52,6 +53,7 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_is_flatpak(self):
+        """Tests getting the Flatpak path to legendary based on configpath setting."""
         checkbinary.configpath.is_flatpak = True
 
         expected_base_path = "/app/bin/heroic"
@@ -64,6 +66,7 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_app(self):
+        """Tests getting legendary from the system-wide /app/bin/heroic path"""
         expected_base_path = "/app/bin/heroic"
         expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary")
         os.path.exists.side_effect = lambda x: x == expected_base_path or x == os.path.join(expected_base_path, checkbinary.resources_bin_path)
@@ -74,6 +77,7 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_appimage_gamefiles(self):
+        """Tests the AppImage path for getting legendary when running from the GameFiles folder."""
         expected_base_path = "/home/user/Games/Heroic/HeroicBashLauncher"
         os.getcwd.return_value = os.path.join(expected_base_path, "GameFiles")
         os.path.exists.side_effect = lambda x: expected_base_path in x
@@ -84,6 +88,7 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_appimage(self):
+        """Tests the AppImage path for getting legendary when running from the HeroicBashLauncher folder."""
         expected_base_path = "/home/user/Games/Heroic/HeroicBashLauncher"
         os.getcwd.return_value = os.path.join(expected_base_path)
         os.path.exists.side_effect = lambda x: x == expected_base_path or x == os.path.join(expected_base_path, "binaries")
@@ -94,6 +99,7 @@ class TestCheckBinary(TestCase):
     
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_on_path(self):
+        """Tests finding the legendary binary when heroic exists on the user's PATH"""
         shutil.which.side_effect = lambda x: "/usr/lib64/heroic-games-launcher-bin/heroic" if x == "heroic" else None
         os.path.realpath.side_effect = lambda x: "/usr/lib64/heroic-games-launcher-bin/heroic" if x == "/usr/lib64/heroic-games-launcher-bin/heroic" else x
         expected_base_path = "/usr/lib64/heroic-games-launcher-bin"
@@ -103,6 +109,19 @@ class TestCheckBinary(TestCase):
         actual_return_path = checkbinary.getbinary("epic")
         assert expected_return_path == actual_return_path
 
+    @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
+    def test_getbinary_epic_is_flatpak_and_on_path(self):
+        """When Heroic is installed on the system and on Flatpak, we should perfer the Flatpak."""
+        checkbinary.configpath.is_flatpak = True
+        shutil.which.side_effect = lambda x: "/usr/lib64/heroic-games-launcher-bin/heroic" if x == "heroic" else None
+        os.path.realpath.side_effect = lambda x: "/usr/lib64/heroic-games-launcher-bin/heroic" if x == "/usr/lib64/heroic-games-launcher-bin/heroic" else x
+
+
+        expected_base_path = "/app/bin/heroic"
+        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary")
+
+        actual_return_path = checkbinary.getbinary("epic")
+        assert expected_return_path == actual_return_path
 
 if __name__ == '__main__':
     main()

--- a/tests/testconfigpath.py
+++ b/tests/testconfigpath.py
@@ -1,0 +1,55 @@
+
+
+
+import os
+from subprocess import CompletedProcess
+import subprocess
+from unittest import TestCase
+from unittest.mock import Mock
+
+from func import configpath
+
+def mock_subprocess_run_hgl(args, **kwargs):
+    stdout = b"com.heroicgameslauncher.hgl\n" if args == ["flatpak", "list", "--columns=application"] else None
+    returncode = 0
+    return CompletedProcess(args, returncode, stdout)
+
+def mock_subprocess_run_steam(args, **kwargs):
+    stdout = b"com.valvesoftware.Steam\n" if args == ["flatpak", "list", "--columns=application"] else None
+    returncode = 0
+    return CompletedProcess(args, returncode, stdout)
+
+class TestCheckBinary(TestCase):
+
+    def setUp(self):
+        subprocess.run = Mock(return_value=CompletedProcess([], returncode=0, stdout=b""))
+        os.path.expanduser = Mock(side_effect=lambda path: path.replace('~', "/home/user"))
+        os.path.exists = Mock(return_value=False)
+
+    def test_is_flatpak_installed_nothing(self):
+        """Tests that no flatpaks are installed when the output is empty"""
+        assert configpath.is_flatpak_installed(configpath.HGL_FLATPAK_APPID) == False
+        assert configpath.is_flatpak_installed(configpath.STEAM_FLATPAK_APPID) == False
+
+    def test_is_flatpak_installed_non_zero_retcode(self):
+        """Tests that is_flatpak_installed returns False when the flatpak command returns a non-zero status."""
+        subprocess.run = Mock(return_value=CompletedProcess([], returncode=127, stdout=b""))
+        assert configpath.is_flatpak_installed(configpath.HGL_FLATPAK_APPID) == False
+        assert configpath.is_flatpak_installed(configpath.STEAM_FLATPAK_APPID) == False
+    
+    def test_is_flatpak_installed_only_config_exists(self):
+        """Tests that is_flatpak_installed returns False when only the config folder exists"""
+        os.path.exists.side_effect = lambda path: path == f"/home/user/.var/app/{configpath.HGL_FLATPAK_APPID}"
+        assert configpath.is_flatpak_installed(configpath.HGL_FLATPAK_APPID) == False
+
+    def test_is_flatpak_installed_hgl(self):
+        """Tests that is_flatpak_installed returns True when Heroic Flatpak is installed and the config folder exists."""
+        os.path.exists.side_effect = lambda path: path == f"/home/user/.var/app/{configpath.HGL_FLATPAK_APPID}"
+        subprocess.run = Mock(side_effect=mock_subprocess_run_hgl)
+        assert configpath.is_flatpak_installed(configpath.HGL_FLATPAK_APPID) == True
+
+    def test_is_flatpak_installed_steam(self):
+        """Tests that is_flatpak_installed returns True when Steam Flatpak is installed and the config folder exists."""
+        os.path.exists.side_effect = lambda path: path == f"/home/user/.var/app/{configpath.STEAM_FLATPAK_APPID}"
+        subprocess.run = Mock(side_effect=mock_subprocess_run_steam)
+        assert configpath.is_flatpak_installed(configpath.STEAM_FLATPAK_APPID) == True


### PR DESCRIPTION
This PR addresses #102 by improving HeroicGamesLauncher Flatpak detection by attempting to check the output of the `flatpak list` command.

It also addresses the potential inconsistency discussed in #117 between checkbinary and configpath by having checkbinary prefer the Flatpak installation when `configpath.is_flatpak == True`.