### PR TITLE
[Maintenance] Improve handling of arguments and environment variables

### DIFF
--- a/func/checkbinary.py
+++ b/func/checkbinary.py
@@ -23,9 +23,9 @@ def getbinary(gametype):
         binary = ""
         
         if gametype != "epic":
-            executable = "gogdl "
+            executable = "gogdl"
         else:
-            executable = "legendary "
+            executable = "legendary"
 
         heroic_base_path = None
 
@@ -48,10 +48,10 @@ def getbinary(gametype):
             binary = os.path.join(heroic_resources_path, executable)
         elif heroicconfig["defaultSettings"].get("altLegendaryBin") and gametype == "epic":
 
-                binary = heroicconfig["defaultSettings"]["altLegendaryBin"] + " "
+                binary = heroicconfig["defaultSettings"]["altLegendaryBin"]
         #elif 'altGogdlBin' in heroicconfig['defaultSettings'].keys() and heroicconfig["defaultSettings"]["altGogdlBin"] != "" and gametype != "epic":
         
-                #binary = heroicconfig["defaultSettings"]["altGogdlBin"] + " "
+                #binary = heroicconfig["defaultSettings"]["altGogdlBin"]
         else:#AppImage
             if "GameFiles" in os.getcwd():#select parent dir
                 binary = os.path.join(os.path.dirname(os.getcwd()), "binaries", executable)

--- a/func/checkparameters.py
+++ b/func/checkparameters.py
@@ -32,11 +32,6 @@ def checkparameters(appname, gamejsonfile, gametype):
 
     # Set environment variables first
 
-    #audioFix
-    # TODO: Remove audioFix - was removed in 2.5.0
-    if gameSettings.get("audioFix"):
-        environment["PULSE_LATENCY_MSEC"] = "60"
-
     #showFps
     if gameSettings.get("showFps"):
         environment["DVXK_HUD"] = "fps"
@@ -76,11 +71,6 @@ def checkparameters(appname, gamejsonfile, gametype):
         environment["PROTON_BATTLEYE_RUNTIME"] = configpath.runtimepath
         battlEyeRuntimeArgs = ["battleye_runtime"]
     wrapperArgs += battlEyeRuntimeArgs
-
-    #enableResizableBar
-    # TODO: Remove. Was removed in https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/1921
-    if gameSettings.get("enableResizableBar"):
-        environment["VKD3D_CONFIG"] = "upload_hvv"
 
 
     #nvidiaPrime

--- a/func/checkparameters.py
+++ b/func/checkparameters.py
@@ -45,18 +45,6 @@ def checkparameters(appname, gamejsonfile, gametype):
         environment["WINE_FULLSCREEN_FSR"] = "1"
         environment["WINE_FULLSCREEN_FSR_STRENGTH"] = str(gameSettings.get("maxSharpness"))
 
-    #enableEsync
-    if gameSettings.get("enableEsync"):
-        environment["WINEESYNC"] = "1"
-    else: 
-        environment["PROTON_NO_ESYNC"] = "1"
-
-    #enableFsync (Wine, Proton)
-    if gameSettings.get("enableFsync"):
-        environment["WINEFSYNC"] = "1"
-    else:
-        environment["PROTON_NO_FSYNC"] = "1"
-
     wrapperArgs = []
     #eacRuntime
     eacRuntimeArgs =  []
@@ -210,6 +198,19 @@ def checkparameters(appname, gamejsonfile, gametype):
         wineVersion_bin = heroicconfig["defaultSettings"]["wineVersion"]["bin"]
         wineVersion_name = heroicconfig["defaultSettings"]["wineVersion"]["name"]
         wineVersion_type = heroicconfig["defaultSettings"]["wineVersion"]["type"]
+
+      #enableEsync
+      if gameSettings.get("enableEsync") and wineVersion_type == "wine":
+          environment["WINEESYNC"] = "1"
+      elif not gameSettings.get("enableEsync") and wineVersion_type == "proton":
+          environment["PROTON_NO_ESYNC"] = "1"
+
+      #enableFsync
+      if gameSettings.get("enableFsync") and wineVersion_type == "wine":
+          environment["WINEFSYNC"] = "1"
+      elif not gameSettings.get("enableFsync") and wineVersion_type == "proton":
+          environment["PROTON_NO_FSYNC"] = "1"
+
       if wineVersion_type == "wine":
 
         binArgs = ["--wine", wineVersion_bin]

--- a/tests/testcheckbinary.py
+++ b/tests/testcheckbinary.py
@@ -36,7 +36,7 @@ class TestCheckBinary(TestCase):
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_opt(self):
         expected_base_path = "/opt/Heroic"
-        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
+        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary")
         os.path.exists.side_effect = lambda x: expected_base_path in x
 
         actual_return_path = checkbinary.getbinary("epic")
@@ -45,7 +45,7 @@ class TestCheckBinary(TestCase):
 
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_str)), create=True)
     def test_getbinary_epic_from_config(self):
-        expected_return_path = mock_config_obj["defaultSettings"]["altLegendaryBin"] + " "
+        expected_return_path = mock_config_obj["defaultSettings"]["altLegendaryBin"]
         expected_base_path = os.path.dirname(expected_return_path)
         os.path.exists.side_effect = lambda x: expected_base_path in x
 
@@ -57,7 +57,7 @@ class TestCheckBinary(TestCase):
         checkbinary.configpath.is_flatpak = True
 
         expected_base_path = "/app/bin/heroic"
-        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
+        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary")
         # Path does not exist on host when using flatpak
         os.path.exists.return_value = False
 
@@ -67,7 +67,7 @@ class TestCheckBinary(TestCase):
     @mock.patch("builtins.open", Mock(return_value=StringIO(mock_config_null)), create=True)
     def test_getbinary_epic_app(self):
         expected_base_path = "/app/bin/heroic"
-        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
+        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary")
         os.path.exists.side_effect = lambda x: x == expected_base_path or x == os.path.join(expected_base_path, checkbinary.resources_bin_path)
 
         actual_return_path = checkbinary.getbinary("epic")
@@ -80,7 +80,7 @@ class TestCheckBinary(TestCase):
         os.getcwd.return_value = os.path.join(expected_base_path, "GameFiles")
         os.path.exists.side_effect = lambda x: expected_base_path in x
 
-        expected_return_path = os.path.join(expected_base_path, "binaries/legendary ")
+        expected_return_path = os.path.join(expected_base_path, "binaries/legendary")
         actual_return_path = checkbinary.getbinary("epic")
         assert expected_return_path == actual_return_path
 
@@ -90,7 +90,7 @@ class TestCheckBinary(TestCase):
         os.getcwd.return_value = os.path.join(expected_base_path)
         os.path.exists.side_effect = lambda x: x == expected_base_path or x == os.path.join(expected_base_path, "binaries")
 
-        expected_return_path = os.path.join(expected_base_path, "binaries/legendary ")
+        expected_return_path = os.path.join(expected_base_path, "binaries/legendary")
         actual_return_path = checkbinary.getbinary("epic")
         assert expected_return_path == actual_return_path
     
@@ -99,7 +99,7 @@ class TestCheckBinary(TestCase):
         shutil.which.side_effect = lambda x: "/usr/lib64/heroic-games-launcher-bin/heroic" if x == "heroic" else None
         os.path.realpath.side_effect = lambda x: "/usr/lib64/heroic-games-launcher-bin/heroic" if x == "/usr/lib64/heroic-games-launcher-bin/heroic" else x
         expected_base_path = "/usr/lib64/heroic-games-launcher-bin"
-        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary ")
+        expected_return_path = os.path.join(expected_base_path, checkbinary.resources_bin_path, "legendary")
         os.path.exists.side_effect = lambda x: expected_base_path in x
 
         actual_return_path = checkbinary.getbinary("epic")

--- a/tests/testcheckbinary.py
+++ b/tests/testcheckbinary.py
@@ -6,8 +6,6 @@ from io import StringIO
 from unittest import main, mock, TestCase
 from unittest.mock import Mock
 
-from func import configpath
-from func.settings import args
 from func import checkbinary
 
 mock_config_null = json.dumps({ "defaultSettings": { "altLegendaryBin": "" } })

--- a/tests/testcheckparameters.py
+++ b/tests/testcheckparameters.py
@@ -147,7 +147,7 @@ class TestCheckBinary(TestCase):
     @mock.patch("builtins.open", default_mock_open, create=True)
     def test_getparameters_epic_wine_no_args(self):
         """Tests an Epic + Wine game config and store config with "minimal" settings and options selected."""
-        expected_environment = {'PROTON_NO_ESYNC': '1', 'PROTON_NO_FSYNC': '1', 'LD_PRELOAD': ''}
+        expected_environment = {'LD_PRELOAD': ''}
         expected_arguments = [
             MOCK_HEROIC_PATH, 'launch', MOCK_APP_NAME,
             # default language
@@ -177,10 +177,6 @@ class TestCheckBinary(TestCase):
             'WINE_FULLSCREEN_FSR': '1',
             # maxSharpness
             'WINE_FULLSCREEN_FSR_STRENGTH': str(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['maxSharpness']),
-            # enableEsync
-            'WINEESYNC': '1', 
-            # enableFsync
-            'WINEFSYNC': '1',
             # eacRuntime
             'PROTON_EAC_RUNTIME': MOCK_RUNTIME_PATH,
             # battlEyeRuntime
@@ -244,10 +240,6 @@ class TestCheckBinary(TestCase):
             'WINE_FULLSCREEN_FSR': '1',
             # maxSharpness
             'WINE_FULLSCREEN_FSR_STRENGTH': str(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['maxSharpness']),
-            # enableEsync
-            'WINEESYNC': '1', 
-            # enableFsync
-            'WINEFSYNC': '1',
             # eacRuntime
             'PROTON_EAC_RUNTIME': MOCK_RUNTIME_PATH,
             # battlEyeRuntime
@@ -313,10 +305,6 @@ class TestCheckBinary(TestCase):
             'WINE_FULLSCREEN_FSR': '1',
             # maxSharpness
             'WINE_FULLSCREEN_FSR_STRENGTH': str(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['maxSharpness']),
-            # enableEsync
-            'WINEESYNC': '1', 
-            # enableFsync
-            'WINEFSYNC': '1',
             # eacRuntime
             'PROTON_EAC_RUNTIME': MOCK_RUNTIME_PATH,
             # battlEyeRuntime

--- a/tests/testcheckparameters.py
+++ b/tests/testcheckparameters.py
@@ -41,7 +41,6 @@ MOCK_GAME_CONFIG_MIN_OBJ = {MOCK_APP_NAME: {"winePrefix": f"/path/to/{MOCK_APP_N
 
 # A configuration with all value set/enabled (except preferSystemLibs and useSteamRuntime.)
 MOCK_GAME_CONFIG_FULL_OBJ = {MOCK_APP_NAME: {
-    "audioFix": True,
     "autoSyncSaves": True,
     "battlEyeRuntime": True,
     "DXVKFpsCap": 144,
@@ -50,7 +49,6 @@ MOCK_GAME_CONFIG_FULL_OBJ = {MOCK_APP_NAME: {
     "enableEsync": True,
     "enableFSR": True,
     "enableFsync": True,
-    "enableResizableBar": True,
     "enviromentOptions": [
         {'key': env[0], 'value': env[1]} for env in MOCK_ENVIRONMENT.items()
     ],
@@ -171,8 +169,6 @@ class TestCheckBinary(TestCase):
     def test_getparameters_epic_proton_all_options(self):
         """"Tests an Epic + Wine game using a wineVersion with type 'proton' and all options populated."""
         expected_environment = {
-            # audioFix (deprecated)
-            'PULSE_LATENCY_MSEC': '60',
             # showHud
             'DVXK_HUD': 'fps',
             # enableDXVKFpsLimit
@@ -189,8 +185,6 @@ class TestCheckBinary(TestCase):
             'PROTON_EAC_RUNTIME': MOCK_RUNTIME_PATH,
             # battlEyeRuntime
             'PROTON_BATTLEYE_RUNTIME': MOCK_RUNTIME_PATH,
-            # enableResizableBar (deprecatedd)
-            'VKD3D_CONFIG': 'upload_hvv',
             # nvidiaPrime
             'DRI_PRIME': '1',
             '__NV_PRIME_RENDER_OFFLOAD': '1',
@@ -242,8 +236,6 @@ class TestCheckBinary(TestCase):
     def test_getparameters_epic_proton_steam_runtime_all_options(self):
         """Tests an Epic + Proton game config with useSteamRuntime and all options populated."""
         expected_environment = {
-            # audioFix (deprecated)
-            'PULSE_LATENCY_MSEC': '60',
             # showHud
             'DVXK_HUD': 'fps',
             # enableDXVKFpsLimit
@@ -260,8 +252,6 @@ class TestCheckBinary(TestCase):
             'PROTON_EAC_RUNTIME': MOCK_RUNTIME_PATH,
             # battlEyeRuntime
             'PROTON_BATTLEYE_RUNTIME': MOCK_RUNTIME_PATH,
-            # enableResizableBar (deprecatedd)
-            'VKD3D_CONFIG': 'upload_hvv',
             # nvidiaPrime
             'DRI_PRIME': '1',
             '__NV_PRIME_RENDER_OFFLOAD': '1',
@@ -315,8 +305,6 @@ class TestCheckBinary(TestCase):
     def test_checkparameters_gog_linux(self):
         """Tests a GOG Linux game with all configuration options enabled."""
         expected_environment = {
-            # audioFix (deprecated)
-            'PULSE_LATENCY_MSEC': '60',
             # showHud
             'DVXK_HUD': 'fps',
             # enableDXVKFpsLimit
@@ -333,8 +321,6 @@ class TestCheckBinary(TestCase):
             'PROTON_EAC_RUNTIME': MOCK_RUNTIME_PATH,
             # battlEyeRuntime
             'PROTON_BATTLEYE_RUNTIME': MOCK_RUNTIME_PATH,
-            # enableResizableBar (deprecatedd)
-            'VKD3D_CONFIG': 'upload_hvv',
             # nvidiaPrime
             'DRI_PRIME': '1',
             '__NV_PRIME_RENDER_OFFLOAD': '1',
@@ -355,8 +341,6 @@ class TestCheckBinary(TestCase):
     def test_checkparameters_epic_wine_custom_libs(self):
         """Tests that an Epic + Wine game with useSystemLibs = False returns the expected values."""
         expected_environment = {
-            # audioFix (deprecated)
-            'PULSE_LATENCY_MSEC': '60',
             # showHud
             'DVXK_HUD': 'fps',
             # enableDXVKFpsLimit
@@ -373,8 +357,6 @@ class TestCheckBinary(TestCase):
             'PROTON_EAC_RUNTIME': MOCK_RUNTIME_PATH,
             # battlEyeRuntime
             'PROTON_BATTLEYE_RUNTIME': MOCK_RUNTIME_PATH,
-            # enableResizableBar (deprecatedd)
-            'VKD3D_CONFIG': 'upload_hvv',
             # nvidiaPrime
             'DRI_PRIME': '1',
             '__NV_PRIME_RENDER_OFFLOAD': '1',

--- a/tests/testcheckparameters.py
+++ b/tests/testcheckparameters.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+import copy
+import os
+import json
+import shlex
+import shutil
+from io import StringIO
+from unittest import main, mock, TestCase
+from unittest.mock import Mock
+
+
+from func import checkparameters
+
+MOCK_APP_NAME = "TestGameId"
+
+# Mock configpath values
+MOCK_GAME_JSON_PATH = "/path/to/gameconfig.json"
+MOCK_HEROIC_CONFIG_PATH = "/path/to/heroicconfig.json"
+MOCK_STORE_CONFIG_PATH = "/path/to/storeconfig.json"
+MOCK_RUNTIME_PATH = "/path/to/runtimes"
+MOCK_GOG_INSTALLED_CONFIG_PATH = "/path/to/goginstalled.json"
+# mock getbinary paths
+MOCK_HEROIC_PATH = "/path/to/heroic"
+MOCK_GOGDL_PATH = "/path/to/gog-dl"
+
+# A dictionary to mock environmentOptions for ease of mapping to/from
+MOCK_ENVIRONMENT = { "MY_TEST_ENV": "MY_TEST_VALUE" }
+
+# The default heroic config.
+MOCK_HEROIC_CONFIG_OBJ = {"defaultSettings": {
+    "altLegendaryBin": "",
+    "wineVersion": {
+        "bin": "/path/to/bin/wine",
+        "name": "Wine - Default",
+        "type": "wine"
+    }
+}}
+
+# A "minimal" working config with only the winePrefix populated.
+MOCK_GAME_CONFIG_MIN_OBJ = {MOCK_APP_NAME: {"winePrefix": f"/path/to/{MOCK_APP_NAME}/pfx"}}
+
+# A configuration with all value set/enabled (except preferSystemLibs and useSteamRuntime.)
+MOCK_GAME_CONFIG_FULL_OBJ = {MOCK_APP_NAME: {
+    "audioFix": True,
+    "autoSyncSaves": True,
+    "battlEyeRuntime": True,
+    "DXVKFpsCap": 144,
+    "eacRuntime": True,
+    "enableDXVKFpsLimit": True,
+    "enableEsync": True,
+    "enableFSR": True,
+    "enableFsync": True,
+    "enableResizableBar": True,
+    "enviromentOptions": [
+        {'key': env[0], 'value': env[1]} for env in MOCK_ENVIRONMENT.items()
+    ],
+    "language": "fr",
+    "launcherArgs": "launcherArgsValue",
+    "maxSharpness": 2,
+    "nvidiaPrime": True,
+    "offlineMode": True,
+    "preferSystemLibs": False,
+    "savesPath": "/path/to/saves",
+    "showFps": True,
+    "showMangohud": True,
+    "targetExe": "/path/to/override/exe",
+    "useGameMode": True,
+    "useSteamRuntime": False,
+    "winePrefix": f"/path/to/{MOCK_APP_NAME}/pfx",
+    "wineVersion": {
+        "bin": "/path/to/game/wine/bin/wine",
+        "name": f"Wine - {MOCK_APP_NAME}",
+        "type": "wine",
+        "lib": "/path/to/game/wine/lib",
+        "lib32": "/path/to/game/wine/lib32"
+    },
+    "wrapperOptions": [{
+        "exe": "/my/test/wrapper",
+        "args": "--my --test --args"
+    }]
+}}
+
+# Override wineVersion with Proton.
+MOCK_GAME_CONFIG_PROTON_OBJ = copy.deepcopy(MOCK_GAME_CONFIG_FULL_OBJ)
+MOCK_GAME_CONFIG_PROTON_OBJ[MOCK_APP_NAME]['wineVersion'] = {
+    'bin': "/path/to/proton",
+    'name': f"Proton - {MOCK_APP_NAME}",
+    'type': "proton"
+}
+
+# enable useSteamRuntime in a Proton config
+MOCK_GAME_CONFIG_STEAM_RUNTIME_OBJ = copy.deepcopy(MOCK_GAME_CONFIG_PROTON_OBJ)
+MOCK_GAME_CONFIG_STEAM_RUNTIME_OBJ[MOCK_APP_NAME]['useSteamRuntime'] = True
+
+# A minimal store config to test the default language
+MOCK_STORE_CONFIG_LANGUAGE_OBJ = {'language': 'en'}
+
+MOCK_GOG_INSTALLED_OBJ = {"installed": [{
+    "appName": MOCK_APP_NAME,
+    "install_path": "/path/to/gog/game"
+    }]}
+MOCK_GOG_INSTALLED_STR = json.dumps(MOCK_GOG_INSTALLED_OBJ)
+
+def get_mocked_config(filename: str, game_config_obj=MOCK_GAME_CONFIG_MIN_OBJ, heroic_config_obj=MOCK_HEROIC_CONFIG_OBJ, store_config_obj=MOCK_STORE_CONFIG_LANGUAGE_OBJ, gog_installed_obj=MOCK_GOG_INSTALLED_OBJ):
+    if filename == MOCK_GAME_JSON_PATH:
+        return json.dumps(game_config_obj)
+    elif filename == MOCK_HEROIC_CONFIG_PATH:
+        return json.dumps(heroic_config_obj)
+    elif filename == MOCK_STORE_CONFIG_PATH:
+        return json.dumps(store_config_obj)
+    elif filename == MOCK_GOG_INSTALLED_CONFIG_PATH:
+        return json.dumps(gog_installed_obj)
+    else:
+        return "{}"
+
+default_mock_open = Mock(side_effect=lambda filename, *args, **
+                 kwargs: StringIO(get_mocked_config(filename)))
+
+
+class TestCheckBinary(TestCase):
+
+    def setUp(self):
+        # By default which will return nothing (no heroic on PATH)
+        shutil.which = Mock()
+        shutil.which.return_value = None
+
+        # Initialize other mocks
+        os.path.expanduser = Mock(side_effect=lambda path: path.replace('~', "/home/user"))
+        # Treat os.environ like an empty dictionary for testing (no existing values)
+        os.environ = {}
+
+        # By default we won't test the flatpak path.
+        checkparameters.configpath = Mock()
+        checkparameters.configpath.is_flatpak = False
+        checkparameters.configpath.is_steam_flatpak = False
+        checkparameters.configpath.heroicconfigpath = MOCK_HEROIC_CONFIG_PATH
+        checkparameters.configpath.runtimepath = MOCK_RUNTIME_PATH
+        checkparameters.configpath.storejsonpath = MOCK_STORE_CONFIG_PATH
+        checkparameters.configpath.goginstalledpath = MOCK_GOG_INSTALLED_CONFIG_PATH
+        
+        # Mock getbinary for epic and gog-dl
+        checkparameters.getbinary = Mock(
+            side_effect=lambda gametype: MOCK_HEROIC_PATH if gametype == "epic" else MOCK_GOGDL_PATH)
+
+        # Disable zenity and logging output during testing.
+        checkparameters.args.silent = True
+        checkparameters.logging.disable(checkparameters.logging.CRITICAL)
+
+    @mock.patch("builtins.open", default_mock_open, create=True)
+    def test_getparameters_epic_wine_no_args(self):
+        """Tests an Epic + Wine game config and store config with "minimal" settings and options selected."""
+        expected_environment = {'PROTON_NO_ESYNC': '1', 'PROTON_NO_FSYNC': '1', 'LD_PRELOAD': ''}
+        expected_arguments = [
+            MOCK_HEROIC_PATH, 'launch', MOCK_APP_NAME,
+            # default language
+            "--language", MOCK_STORE_CONFIG_LANGUAGE_OBJ["language"],
+            # default winePrefix
+            '--wine-prefix', MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]["winePrefix"],
+            # default wineVersion.bin
+            '--wine',  MOCK_HEROIC_CONFIG_OBJ["defaultSettings"]["wineVersion"]["bin"],
+        ]
+        expected_cloudsync = ''
+
+        actual_environment, actual_arguments, actual_cloudsync = checkparameters.checkparameters(
+            MOCK_APP_NAME, MOCK_GAME_JSON_PATH, "epic")
+        assert expected_environment == actual_environment
+        assert expected_arguments == actual_arguments
+        assert expected_cloudsync == actual_cloudsync    
+    
+    @mock.patch("builtins.open", Mock(side_effect=lambda filename, *args, **kwargs: StringIO(get_mocked_config(filename, game_config_obj=MOCK_GAME_CONFIG_PROTON_OBJ))), create=True)
+    def test_getparameters_epic_proton_all_options(self):
+        """"Tests an Epic + Wine game using a wineVersion with type 'proton' and all options populated."""
+        expected_environment = {
+            # audioFix (deprecated)
+            'PULSE_LATENCY_MSEC': '60',
+            # showHud
+            'DVXK_HUD': 'fps',
+            # enableDXVKFpsLimit
+            'DXVK_FRAME_RATE': str(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['DXVKFpsCap']),
+            # enableFSR
+            'WINE_FULLSCREEN_FSR': '1',
+            # maxSharpness
+            'WINE_FULLSCREEN_FSR_STRENGTH': str(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['maxSharpness']),
+            # enableEsync
+            'WINEESYNC': '1', 
+            # enableFsync
+            'WINEFSYNC': '1',
+            # eacRuntime
+            'PROTON_EAC_RUNTIME': MOCK_RUNTIME_PATH,
+            # battlEyeRuntime
+            'PROTON_BATTLEYE_RUNTIME': MOCK_RUNTIME_PATH,
+            # enableResizableBar (deprecatedd)
+            'VKD3D_CONFIG': 'upload_hvv',
+            # nvidiaPrime
+            'DRI_PRIME': '1',
+            '__NV_PRIME_RENDER_OFFLOAD': '1',
+            '__GLX_VENDOR_LIBRARY_NAME': 'nvidia',
+            'LD_PRELOAD': '',
+            # proton variables
+            'STEAM_COMPAT_CLIENT_INSTALL_PATH': '/home/user/.steam/steam',
+            'STEAM_COMPAT_DATA_PATH': MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]["winePrefix"],
+            'STEAM_COMPAT_APP_ID': '0',
+            'SteamAppId': '0'
+            }
+        # enviromentOptions
+        expected_environment = expected_environment | MOCK_ENVIRONMENT
+        expected_arguments = [
+            # eacRuntime
+            'eac_runtime',
+            # battlEyeRuntime
+            'battleye_runtime',
+            # wrapperOptions
+            MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['wrapperOptions'][0]['exe'],
+            # unpack list of wrapper args
+            *shlex.split(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['wrapperOptions'][0]['args']),
+            # showMangohud
+            'mangohud', '--dlsym',
+            # useGameMode
+            'gamemoderun',
+            MOCK_HEROIC_PATH, 'launch', MOCK_APP_NAME,
+            # targetExe
+            '--override-exe', f"\"{MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['targetExe']}\"",
+            # offlineMode
+            '--offline',
+            # language
+            '--language', MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]["language"],
+            # wineVersion.type == Proton
+            "--no-wine",
+            "--wrapper", f"\"{MOCK_GAME_CONFIG_PROTON_OBJ[MOCK_APP_NAME]['wineVersion']['bin']}\"",
+            "run",
+            # launcherArgs
+            MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['launcherArgs']
+        ]
+        expected_cloudsync = "/path/to/heroic sync-saves --save-path \"/path/to/saves\" TestGameId -y"
+        actual_environment, actual_arguments, actual_cloudsync = checkparameters.checkparameters(
+            MOCK_APP_NAME, MOCK_GAME_JSON_PATH, "epic")
+        assert expected_environment == actual_environment
+        assert expected_arguments == actual_arguments
+        assert expected_cloudsync == actual_cloudsync
+
+    @mock.patch("builtins.open", Mock(side_effect=lambda filename, *args, **kwargs: StringIO(get_mocked_config(filename, game_config_obj=MOCK_GAME_CONFIG_STEAM_RUNTIME_OBJ))), create=True)
+    def test_getparameters_epic_proton_steam_runtime_all_options(self):
+        """Tests an Epic + Proton game config with useSteamRuntime and all options populated."""
+        expected_environment = {
+            # audioFix (deprecated)
+            'PULSE_LATENCY_MSEC': '60',
+            # showHud
+            'DVXK_HUD': 'fps',
+            # enableDXVKFpsLimit
+            'DXVK_FRAME_RATE': str(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['DXVKFpsCap']),
+            # enableFSR
+            'WINE_FULLSCREEN_FSR': '1',
+            # maxSharpness
+            'WINE_FULLSCREEN_FSR_STRENGTH': str(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['maxSharpness']),
+            # enableEsync
+            'WINEESYNC': '1', 
+            # enableFsync
+            'WINEFSYNC': '1',
+            # eacRuntime
+            'PROTON_EAC_RUNTIME': MOCK_RUNTIME_PATH,
+            # battlEyeRuntime
+            'PROTON_BATTLEYE_RUNTIME': MOCK_RUNTIME_PATH,
+            # enableResizableBar (deprecatedd)
+            'VKD3D_CONFIG': 'upload_hvv',
+            # nvidiaPrime
+            'DRI_PRIME': '1',
+            '__NV_PRIME_RENDER_OFFLOAD': '1',
+            '__GLX_VENDOR_LIBRARY_NAME': 'nvidia',
+            'LD_PRELOAD': '',
+            # proton variables
+            'STEAM_COMPAT_CLIENT_INSTALL_PATH': '/home/user/.steam/steam',
+            'STEAM_COMPAT_DATA_PATH': MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]["winePrefix"],
+            'STEAM_COMPAT_APP_ID': '0',
+            'SteamAppId': '0'
+            }
+        # enviromentOptions
+        expected_environment = expected_environment | MOCK_ENVIRONMENT
+        expected_arguments = [
+            # eacRuntime
+            'eac_runtime',
+            # battlEyeRuntime
+            'battleye_runtime',
+            # wrapperOptions
+            MOCK_GAME_CONFIG_PROTON_OBJ[MOCK_APP_NAME]['wrapperOptions'][0]['exe'],
+            # unpack list of wrapper args
+            *shlex.split(MOCK_GAME_CONFIG_PROTON_OBJ[MOCK_APP_NAME]['wrapperOptions'][0]['args']),
+            # showMangohud
+            'mangohud', '--dlsym',
+            # useGameMode
+            'gamemoderun',
+            MOCK_HEROIC_PATH, 'launch', MOCK_APP_NAME,
+            # targetExe
+            '--override-exe', f"\"{MOCK_GAME_CONFIG_PROTON_OBJ[MOCK_APP_NAME]['targetExe']}\"",
+            # offlineMode
+            '--offline',
+            # language
+            '--language', MOCK_GAME_CONFIG_PROTON_OBJ[MOCK_APP_NAME]["language"],
+            # wineVersion.type == Proton + useSteamRuntime
+            '--no-wine',
+            '--wrapper', '/home/user/.steam/root/steamapps/common/SteamLinuxRuntime_soldier/run', '--',
+            f"\"{MOCK_GAME_CONFIG_PROTON_OBJ[MOCK_APP_NAME]['wineVersion']['bin']}\"", 
+            'waitforexitandrun',
+            # launcherArgs
+            MOCK_GAME_CONFIG_PROTON_OBJ[MOCK_APP_NAME]['launcherArgs']
+        ]
+        # autoSyncSaves + savePath
+        expected_cloudsync = '/path/to/heroic sync-saves --save-path "/path/to/saves" TestGameId -y'
+
+        actual_environment, actual_arguments, actual_cloudsync = checkparameters.checkparameters(MOCK_APP_NAME, MOCK_GAME_JSON_PATH, "epic")
+        assert expected_environment == actual_environment
+        assert expected_arguments == actual_arguments
+        assert expected_cloudsync == actual_cloudsync
+    
+    @mock.patch("builtins.open", Mock(side_effect=lambda filename, *args, **kwargs: StringIO(get_mocked_config(filename, game_config_obj=MOCK_GAME_CONFIG_FULL_OBJ))), create=True)
+    def test_checkparameters_gog_linux(self):
+        """Tests a GOG Linux game with all configuration options enabled."""
+        expected_environment = {
+            # audioFix (deprecated)
+            'PULSE_LATENCY_MSEC': '60',
+            # showHud
+            'DVXK_HUD': 'fps',
+            # enableDXVKFpsLimit
+            'DXVK_FRAME_RATE': str(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['DXVKFpsCap']),
+            # enableFSR
+            'WINE_FULLSCREEN_FSR': '1',
+            # maxSharpness
+            'WINE_FULLSCREEN_FSR_STRENGTH': str(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['maxSharpness']),
+            # enableEsync
+            'WINEESYNC': '1', 
+            # enableFsync
+            'WINEFSYNC': '1',
+            # eacRuntime
+            'PROTON_EAC_RUNTIME': MOCK_RUNTIME_PATH,
+            # battlEyeRuntime
+            'PROTON_BATTLEYE_RUNTIME': MOCK_RUNTIME_PATH,
+            # enableResizableBar (deprecatedd)
+            'VKD3D_CONFIG': 'upload_hvv',
+            # nvidiaPrime
+            'DRI_PRIME': '1',
+            '__NV_PRIME_RENDER_OFFLOAD': '1',
+            '__GLX_VENDOR_LIBRARY_NAME': 'nvidia',
+            'LD_PRELOAD': ''
+        }
+        # environmentOptions
+        expected_environment = expected_environment | MOCK_ENVIRONMENT
+        expected_arguments = ['eac_runtime', 'battleye_runtime', '/my/test/wrapper', '--my', '--test', '--args', 'mangohud', '--dlsym', 'gamemoderun', '/path/to/gog-dl', 'launch', '"/path/to/gog/game"', 'TestGameId', '--override-exe', '"/path/to/override/exe"', '--offline', '--platform=linux', 'launcherArgsValue']
+        expected_cloudsync = "/path/to/gog-dl sync-saves --save-path \"/path/to/saves\" TestGameId -y"
+        actual_environment, actual_arguments, actual_cloudsync = checkparameters.checkparameters(
+            MOCK_APP_NAME, MOCK_GAME_JSON_PATH, "gog-linux")
+        assert expected_environment == actual_environment
+        assert expected_arguments == actual_arguments
+        assert expected_cloudsync == actual_cloudsync
+
+    @mock.patch("builtins.open", Mock(side_effect=lambda filename, *args, **kwargs: StringIO(get_mocked_config(filename, game_config_obj=MOCK_GAME_CONFIG_FULL_OBJ))), create=True)
+    def test_checkparameters_epic_wine_custom_libs(self):
+        """Tests that an Epic + Wine game with useSystemLibs = False returns the expected values."""
+        expected_environment = {
+            # audioFix (deprecated)
+            'PULSE_LATENCY_MSEC': '60',
+            # showHud
+            'DVXK_HUD': 'fps',
+            # enableDXVKFpsLimit
+            'DXVK_FRAME_RATE': str(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['DXVKFpsCap']),
+            # enableFSR
+            'WINE_FULLSCREEN_FSR': '1',
+            # maxSharpness
+            'WINE_FULLSCREEN_FSR_STRENGTH': str(MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['maxSharpness']),
+            # enableEsync
+            'WINEESYNC': '1', 
+            # enableFsync
+            'WINEFSYNC': '1',
+            # eacRuntime
+            'PROTON_EAC_RUNTIME': MOCK_RUNTIME_PATH,
+            # battlEyeRuntime
+            'PROTON_BATTLEYE_RUNTIME': MOCK_RUNTIME_PATH,
+            # enableResizableBar (deprecatedd)
+            'VKD3D_CONFIG': 'upload_hvv',
+            # nvidiaPrime
+            'DRI_PRIME': '1',
+            '__NV_PRIME_RENDER_OFFLOAD': '1',
+            '__GLX_VENDOR_LIBRARY_NAME': 'nvidia',
+            'LD_PRELOAD': '',
+            'ORIG_LD_LIBRARY_PATH': '',
+            'LD_LIBRARY_PATH': f"{MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['wineVersion']['lib']}:{MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['wineVersion']['lib32']}",
+            'GST_PLUGIN_SYSTEM_PATH_1_0': f"{MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['wineVersion']['lib']}/gstreamer-1.0:{MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['wineVersion']['lib32']}/gstreamer-1.0",
+            'WINEDLLPATH': f"{MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['wineVersion']['lib']}/wine:{MOCK_GAME_CONFIG_FULL_OBJ[MOCK_APP_NAME]['wineVersion']['lib32']}/wine",
+        }
+        # environmentOptions
+        expected_environment = expected_environment | MOCK_ENVIRONMENT
+        expected_arguments = ['eac_runtime', 'battleye_runtime', '/my/test/wrapper', '--my', '--test', '--args', 'mangohud', '--dlsym', 'gamemoderun', '/path/to/heroic', 'launch', 'TestGameId', '--override-exe', '"/path/to/override/exe"', '--offline', '--language', 'fr', '--wine-prefix', '/path/to/TestGameId/pfx', '--wine', '/path/to/game/wine/bin/wine', 'launcherArgsValue']
+        expected_cloudsync = "/path/to/heroic sync-saves --save-path \"/path/to/saves\" TestGameId -y"
+        actual_environment, actual_arguments, actual_cloudsync = checkparameters.checkparameters(
+        MOCK_APP_NAME, MOCK_GAME_JSON_PATH, "epic")
+        assert expected_environment == actual_environment
+        assert expected_arguments == actual_arguments
+        assert expected_cloudsync == actual_cloudsync
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR supports #112 by:
* Removing the separate variable per configuration option and replacing it with a list of arguments and a dictionary of environment variables
* Sharing common lists of arguments between the different types of games.
  * (ex `wrapperArgs` for the wrapper commands goes first)
* Assembling the full list and dictionary into strings during createlaunchfile.
  * Arguments and paths no longer need to be suffixed with a space, as this happens automatically during the string `" ".join()` command in createlaunchfile.
* Returning the list and dictionary also made it easier to create unit tests by looking at the returned lists and dictionary items.
* Removes two options that have been deprecated in HeroicGamesLauncher (`audioFix` and `enableResizableBar`)

Future arguments and environment variables implemented in the HeroicBashLauncher should now only need to:
1. Check the appropriate configuration elements and
2. add the argument(s) or environment variable(s) to the appropriate list or dictionary.